### PR TITLE
Added port 5060 as a default if the via header does not contain a port

### DIFF
--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -504,7 +504,7 @@ IncomingRequest.prototype.reply_sl = function(code, reason) {
   if(length > 0) {
     var via = this.parseHeader('Via');
     host = via.host;
-    port = via.port;
+    port = via.port || 5060;
   }
 
   to = this.getHeader('To');


### PR DESCRIPTION
Freeswitch and other clients may not always populate the port. This fix just sets it to 5060 if not present when parsing the via header.